### PR TITLE
Add and update HTML transformers [TS-311]

### DIFF
--- a/lib/slack_transformer/html.rb
+++ b/lib/slack_transformer/html.rb
@@ -4,6 +4,9 @@ require 'slack_transformer/html/italics'
 require 'slack_transformer/html/lists'
 require 'slack_transformer/html/preformatted'
 require 'slack_transformer/html/strikethrough'
+require 'slack_transformer/html/hyperlink'
+require 'slack_transformer/html/line_break'
+require 'slack_transformer/html/unsupported'
 
 module SlackTransformer
   class Html
@@ -15,7 +18,10 @@ module SlackTransformer
       SlackTransformer::Html::Strikethrough,
       SlackTransformer::Html::Code,
       SlackTransformer::Html::Preformatted,
-      SlackTransformer::Html::Lists
+      SlackTransformer::Html::Lists,
+      SlackTransformer::Html::Hyperlink,
+      SlackTransformer::Html::LineBreak,
+      SlackTransformer::Html::Unsupported
     ]
 
     def initialize(input)

--- a/lib/slack_transformer/html/bold.rb
+++ b/lib/slack_transformer/html/bold.rb
@@ -8,7 +8,7 @@ module SlackTransformer
       end
 
       def to_slack
-        input.gsub(/<\/?b>/, '*')
+        input.gsub(/<\/?(b|strong)>/, '*')
       end
     end
   end

--- a/lib/slack_transformer/html/hyperlink.rb
+++ b/lib/slack_transformer/html/hyperlink.rb
@@ -1,6 +1,6 @@
 module SlackTransformer
   class Html
-    class Italics
+    class Hyperlink
       attr_reader :input
 
       def initialize(input)
@@ -8,7 +8,7 @@ module SlackTransformer
       end
 
       def to_slack
-        input.gsub(/<\/?(i|em)>/, '_')
+        input.gsub /<a [^h]*href=["']([^"']*)["'][^>]*>([^<]*)<\/a>/, "<\\1|\\2>"
       end
     end
   end

--- a/lib/slack_transformer/html/line_break.rb
+++ b/lib/slack_transformer/html/line_break.rb
@@ -1,6 +1,6 @@
 module SlackTransformer
   class Html
-    class Italics
+    class LineBreak
       attr_reader :input
 
       def initialize(input)
@@ -8,7 +8,7 @@ module SlackTransformer
       end
 
       def to_slack
-        input.gsub(/<\/?(i|em)>/, '_')
+        input.gsub('<br>', "\n")
       end
     end
   end

--- a/lib/slack_transformer/html/strikethrough.rb
+++ b/lib/slack_transformer/html/strikethrough.rb
@@ -8,7 +8,7 @@ module SlackTransformer
       end
 
       def to_slack
-        input.gsub(/<\/?s>/, '~')
+        input.gsub(/<\/?(s|del)>/, '~')
       end
     end
   end

--- a/lib/slack_transformer/html/unsupported.rb
+++ b/lib/slack_transformer/html/unsupported.rb
@@ -1,6 +1,6 @@
 module SlackTransformer
   class Html
-    class Italics
+    class Unsupported
       attr_reader :input
 
       def initialize(input)
@@ -8,7 +8,8 @@ module SlackTransformer
       end
 
       def to_slack
-        input.gsub(/<\/?(i|em)>/, '_')
+        # Filter out all remaining < > tags except for Slack links (<http://url|text> or <http://url>)
+        input.gsub(/<(.[^http][^|]*?)>/, '')
       end
     end
   end

--- a/slack_transformer.gemspec
+++ b/slack_transformer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     *Dir['lib/slack_transformer/slack/*.rb']
   ]
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.12.3'
+  s.add_runtime_dependency 'nokogiri', '~> 1.11'
 
   s.add_development_dependency 'rspec', '~> 3.7.0'
 end

--- a/slack_transformer.gemspec
+++ b/slack_transformer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     *Dir['lib/slack_transformer/slack/*.rb']
   ]
 
-  s.add_runtime_dependency 'nokogiri', '~> 1.11.4'
+  s.add_runtime_dependency 'nokogiri', '~> 1.12.3'
 
   s.add_development_dependency 'rspec', '~> 3.7.0'
 end

--- a/spec/slack_transformer/html/bold_spec.rb
+++ b/spec/slack_transformer/html/bold_spec.rb
@@ -1,10 +1,14 @@
 require 'slack_transformer/html/bold'
 
 RSpec.describe SlackTransformer::Html::Bold do
-  let(:transformation) { described_class.new('<b>bold</b>') }
-
   describe '#to_slack' do
     it 'replaces <b> and </b> with *' do
+      transformation = described_class.new('<b>bold</b>')
+      expect(transformation.to_slack).to eq('*bold*')
+    end
+
+    it 'replaces <strong> and </strong> with *' do
+      transformation = described_class.new('<strong>bold</strong>')
       expect(transformation.to_slack).to eq('*bold*')
     end
   end

--- a/spec/slack_transformer/html/hyperlink_spec.rb
+++ b/spec/slack_transformer/html/hyperlink_spec.rb
@@ -1,0 +1,11 @@
+require 'slack_transformer/html/hyperlink'
+
+RSpec.describe SlackTransformer::Html::Hyperlink do
+  let(:transformation) { described_class.new('<a href="http://example.com">Example</a>') }
+
+  describe '#to_slack' do
+    it 'replaces html hyperlinks with mrkdwn links' do
+      expect(transformation.to_slack).to eq('<http://example.com|Example>')
+    end
+  end
+end

--- a/spec/slack_transformer/html/italics_spec.rb
+++ b/spec/slack_transformer/html/italics_spec.rb
@@ -1,10 +1,14 @@
 require 'slack_transformer/html/italics'
 
 RSpec.describe SlackTransformer::Html::Italics do
-  let(:transformation) { described_class.new('<i>italics</i>') }
-
   describe '#to_slack' do
     it 'replaces <i> and </i> with _' do
+      transformation = described_class.new('<i>italics</i>')
+      expect(transformation.to_slack).to eq('_italics_')
+    end
+
+    it 'replaces <em> and </em> with _' do
+      transformation = described_class.new('<em>italics</em>')
       expect(transformation.to_slack).to eq('_italics_')
     end
   end

--- a/spec/slack_transformer/html/line_break_spec.rb
+++ b/spec/slack_transformer/html/line_break_spec.rb
@@ -1,0 +1,11 @@
+require 'slack_transformer/html/line_break'
+
+RSpec.describe SlackTransformer::Html::LineBreak do
+  let(:transformation) { described_class.new('a line of text<br>') }
+
+  describe '#to_slack' do
+    it 'replaces <br> with negative space' do
+      expect(transformation.to_slack).to eq('a line of text ')
+    end
+  end
+end

--- a/spec/slack_transformer/html/strikethrough_spec.rb
+++ b/spec/slack_transformer/html/strikethrough_spec.rb
@@ -1,10 +1,14 @@
 require 'slack_transformer/html/strikethrough'
 
 RSpec.describe SlackTransformer::Html::Strikethrough do
-  let(:transformation) { described_class.new('<s>strikethrough</s>') }
-
   describe '#to_slack' do
     it 'replaces <s> and </s> with ~' do
+      transformation = described_class.new('<s>strikethrough</s>')
+      expect(transformation.to_slack).to eq('~strikethrough~')
+    end
+
+    it 'replaces <s> and </s> with ~' do
+      transformation = described_class.new('<del>strikethrough</del>')
       expect(transformation.to_slack).to eq('~strikethrough~')
     end
   end

--- a/spec/slack_transformer/html/unsupported_spec.rb
+++ b/spec/slack_transformer/html/unsupported_spec.rb
@@ -1,0 +1,20 @@
+require 'slack_transformer/html/unsupported'
+
+RSpec.describe SlackTransformer::Html::Unsupported do
+  describe '#to_slack' do
+    it 'removes unsupported HTML tags' do
+      transformation = described_class.new('<div><section><fake>*bold*</fake></section></div>')
+      expect(transformation.to_slack).to eq('*bold*')
+    end
+
+    it 'does not remove Slack links' do
+      transformation = described_class.new('<div>*bold* <http://example.com|Example></div>')
+      expect(transformation.to_slack).to eq('*bold* <http://example.com|Example>')
+    end
+
+    it 'does not remove Slack links' do
+      transformation = described_class.new('<div>*bold* <http://example.com></div>')
+      expect(transformation.to_slack).to eq('*bold* <http://example.com>')
+    end
+  end
+end


### PR DESCRIPTION
### Description
These changes are a part of [TS-311](https://vendr.atlassian.net/jira/software/projects/TS/boards/17?selectedIssue=TS-311) and get us most of the way there with the exception of [this](https://vendrco.slack.com/archives/C01JEG18MGA/p1626126669031100) bug which will be addressed with [this](https://vendr.atlassian.net/jira/software/projects/TS/boards/17?selectedIssue=TS-337) ticket. Once that is resolved and we are satisfied we can make this a pull request against the official repository for [slack_transformer](https://github.com/everwise/slack_transformer).

Until then we will be pointing to this branch in our fork for the implementation.
 
### Checklist
* Add hyperlink transformer to convert HTML hyperlinks to Mrkdwn links

* Add line break transformer to convert HTML line breaks to negative space until we can get `\n` to work

* Add unsupported transformer to remove remaining html tags, excluding Slack's link tags

* Update the bold transformer to include the semantic `<strong>` tag

* Update the italics transformer to include the semantic `<em>` tag

* Update specs